### PR TITLE
Reverted to JDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       secure: SONAR_TOKEN
       
 jdk:
-  - openjdk11
+  - oraclejdk8
 script:
   - ./gradlew sonarqube -Dsonar.projectKey=Adyel_ServerSam -Dsonar.organization=adyel-github -Dsonar.host.url=https://sonarcloud.io -Dsonar.login=6247954df47068d34c7d5c3ee67f688b0e724b17
 

--- a/build.gradle
+++ b/build.gradle
@@ -56,4 +56,7 @@ dependencies {
 
     // https://github.com/UweTrottmann/tmdb-java
     implementation 'com.uwetrottmann.tmdb2:tmdb-java:2.0.0'
+
+    // https://github.com/wtekiela/opensub4j
+    compile 'com.github.wtekiela:opensub4j:0.2.0'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,5 @@
 plugins {
     id 'application'
-    id 'org.openjfx.javafxplugin' version '0.0.5'
     id "org.sonarqube" version "2.6"    // Static analysis
 }
 
@@ -9,16 +8,12 @@ version '1.0-SNAPSHOT'
 
 mainClassName = 'main.Main'
 
+sourceCompatibility = 1.8
+
 repositories {
     mavenCentral()
     jcenter()
     maven {url 'https://oss.sonatype.org/content/repositories/snapshots'}
-}
-
-javafx {
-    modules = [ 'javafx.controls',
-                'javafx.fxml'
-    ]
 }
 
 
@@ -37,12 +32,6 @@ dependencies {
     // http://www.tinylog.org/
     compile 'org.tinylog:tinylog:1.3.4'
 
-//    // https://square.github.io/retrofit/
-//    compile 'com.squareup.retrofit2:retrofit:2.4.0'
-//
-//    // https://github.com/square/retrofit/tree/master/retrofit-converters/gson
-//    compile 'com.squareup.retrofit2:converter-gson:2.4.0'
-
     // http://hibernate.org/orm/documentation/getting-started/
     compile 'org.hibernate:hibernate-core:5.4.1.Final'
 
@@ -59,11 +48,11 @@ dependencies {
     implementation 'com.uwetrottmann.tmdb2:tmdb-java:2.0.0'
 
     // https://github.com/controlsfx/controlsfx
-    implementation 'org.controlsfx:controlsfx:11.0.0-SNAPSHOT' // org/controlsfx/controlsfx/9.0.1-SNAPSHOT/
+    implementation 'org.controlsfx:controlsfx:8.40.15-SNAPSHOT'
 
     // https://github.com/aalmiray/ikonli
-    implementation 'org.kordamp.ikonli:ikonli-javafx:11.1.0'
-    implementation 'org.kordamp.ikonli:ikonli-typicons-pack:11.1.0'
+    implementation 'org.kordamp.ikonli:ikonli-javafx:2.4.0'
+    implementation 'org.kordamp.ikonli:ikonli-typicons-pack:2.4.0'
 
     // https://github.com/UweTrottmann/tmdb-java
     implementation 'com.uwetrottmann.tmdb2:tmdb-java:2.0.0'

--- a/src/main/java/model/orm/Genre.java
+++ b/src/main/java/model/orm/Genre.java
@@ -1,9 +1,7 @@
 package model.orm;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import javax.persistence.*;
+import java.util.List;
 
 @Entity
 @Table(name = "genre")
@@ -23,4 +21,44 @@ public class Genre {
 
     @Column(name = "genre_name")
     private String name;
+
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {
+            CascadeType.PERSIST, CascadeType.MERGE,
+            CascadeType.DETACH, CascadeType.REFRESH
+    })
+    @JoinTable(name = "movie_genre",
+            joinColumns = @JoinColumn(name = "genre_id"),
+            inverseJoinColumns = @JoinColumn(name = "movie_id")
+    )
+    private List<MovieDetails> movies;
+
+
+
+
+
+    // INFO: Getters & Setters
+
+    public int getGenreID() {
+        return genreID;
+    }
+
+    public void setGenreID(int genreID) {
+        this.genreID = genreID;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public List<MovieDetails> getMovies() {
+        return movies;
+    }
+
+    public void setMovies(List<MovieDetails> movies) {
+        this.movies = movies;
+    }
 }

--- a/src/main/java/model/orm/Genre.java
+++ b/src/main/java/model/orm/Genre.java
@@ -10,6 +10,10 @@ public class Genre {
 
     public Genre(){}
 
+    public Genre(int genreID){
+        this.genreID = genreID;
+    }
+
     public Genre(com.uwetrottmann.tmdb2.entities.Genre genre){
         this.genreID = genre.id;
         this.name = genre.name;

--- a/src/main/java/model/orm/MovieDetails.java
+++ b/src/main/java/model/orm/MovieDetails.java
@@ -1,6 +1,8 @@
 package model.orm;
 
 import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "movie_list")
@@ -10,13 +12,13 @@ public class MovieDetails {
 
 
     public MovieDetails(String fileName, int year) {
-//        this.tmdbId = tmdbId;
         this.fileName = fileName;
         this.year = year;
     }
 
 
     @Id
+    @Column(name = "movie_id")
     @GeneratedValue(strategy= GenerationType.AUTO)
     private int movieID;
 
@@ -49,6 +51,30 @@ public class MovieDetails {
 
     @Column(name = "release_date")
     private String releaseDate;
+
+    @ManyToMany(fetch = FetchType.LAZY, cascade = {
+            CascadeType.PERSIST, CascadeType.MERGE,
+            CascadeType.DETACH, CascadeType.REFRESH
+    })
+    @JoinTable(name = "movie_genre",
+            joinColumns = @JoinColumn(name = "movie_id"),
+            inverseJoinColumns = @JoinColumn(name = "genre_id")
+    )
+    private List<Genre> genres;
+
+
+
+    // INFO: Make life easier
+
+    public void addGenre(Genre genre){
+        if (genres == null){
+            genres = new ArrayList<>();
+        }
+        genres.add(genre);
+    }
+
+
+    // INFO: Getter & Setter
 
     public int getTmdbId() {
         return tmdbId;
@@ -128,5 +154,21 @@ public class MovieDetails {
 
     public void setReleaseDate(String releaseDate) {
         this.releaseDate = releaseDate;
+    }
+
+    public int getMovieID() {
+        return movieID;
+    }
+
+    public void setMovieID(int movieID) {
+        this.movieID = movieID;
+    }
+
+    public List<Genre> getGenres() {
+        return genres;
+    }
+
+    public void setGenres(List<Genre> genres) {
+        this.genres = genres;
     }
 }

--- a/src/main/java/util/Scrapper.java
+++ b/src/main/java/util/Scrapper.java
@@ -71,7 +71,7 @@ public class Scrapper {
             System.out.println(movieData[0] + " " + movieData[1]);
 
 
-            if (movieData != null && movieData.length == 2 && !movieData[1].isEmpty()){
+            if (movieData != null && movieData.length == 2 && !movieData[1].contains("")){
                 session.save(new MovieDetails(movieData[0],Integer.parseInt(movieData[1])) );
             }
         }

--- a/src/main/java/util/Scrapper.java
+++ b/src/main/java/util/Scrapper.java
@@ -71,7 +71,7 @@ public class Scrapper {
             System.out.println(movieData[0] + " " + movieData[1]);
 
 
-            if (movieData != null && movieData.length == 2 && !movieData[1].isBlank()){
+            if (movieData != null && movieData.length == 2 && !movieData[1].isEmpty()){
                 session.save(new MovieDetails(movieData[0],Integer.parseInt(movieData[1])) );
             }
         }

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -31,7 +31,7 @@
         <property name="show_sql">true</property>
 
         <!-- Drop and re-create the database schema on startup -->
-        <property name="hbm2ddl.auto">create</property>
+        <property name="hbm2ddl.auto">update</property>
 
         <mapping class="model.orm.MovieDetails"/>
         <mapping class="model.orm.Genre"/>

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -31,9 +31,10 @@
         <property name="show_sql">true</property>
 
         <!-- Drop and re-create the database schema on startup -->
-        <property name="hbm2ddl.auto">update</property>
+        <property name="hbm2ddl.auto">create</property>
 
         <mapping class="model.orm.MovieDetails"/>
+        <mapping class="model.orm.Genre"/>
 
     </session-factory>
 

--- a/src/main/resources/main/Sample.fxml
+++ b/src/main/resources/main/Sample.fxml
@@ -26,27 +26,11 @@
    <top>
       <ButtonBar prefHeight="81.0" prefWidth="580.0">
         <buttons>
-            <Button maxHeight="60.0" maxWidth="60.0" minHeight="60.0" minWidth="60.0" mnemonicParsing="false" prefHeight="60.0" prefWidth="60.0" style="-fx-background-radius: 20; -fx-border-radius: 20;">
-               <graphic>
-                  <FontIcon iconLiteral="typ-arrow-sync" iconSize="40" selectionFill="#fcf38e" strokeLineCap="ROUND" />
-               </graphic>
-            </Button>
-            <Button layoutX="30.0" layoutY="21.0" maxHeight="60.0" maxWidth="60.0" minHeight="60.0" minWidth="60.0" mnemonicParsing="false" prefHeight="60.0" prefWidth="60.0" style="-fx-background-radius: 20; -fx-border-radius: 20;">
-               <graphic>
-                  <FontIcon iconLiteral="typ-arrow-sync" iconSize="40" selectionFill="#fcf38e" strokeLineCap="ROUND" />
-               </graphic>
-            </Button>
+            <Button maxHeight="60.0" maxWidth="60.0" minHeight="60.0" minWidth="60.0" mnemonicParsing="false" prefHeight="60.0" prefWidth="60.0" style="-fx-background-radius: 20; -fx-border-radius: 20;" />
+            <Button layoutX="30.0" layoutY="21.0" maxHeight="60.0" maxWidth="60.0" minHeight="60.0" minWidth="60.0" mnemonicParsing="false" prefHeight="60.0" prefWidth="60.0" style="-fx-background-radius: 20; -fx-border-radius: 20;" />
             <Region prefHeight="81.0" prefWidth="315.0" />
-            <Button layoutX="30.0" layoutY="21.0" maxHeight="60.0" maxWidth="60.0" minHeight="60.0" minWidth="60.0" mnemonicParsing="false" prefHeight="60.0" prefWidth="60.0" style="-fx-background-radius: 20; -fx-border-radius: 20;">
-               <graphic>
-                  <FontIcon iconLiteral="typ-arrow-sync" iconSize="40" selectionFill="#fcf38e" strokeLineCap="ROUND" />
-               </graphic>
-            </Button>
-            <Button layoutX="30.0" layoutY="21.0" maxHeight="60.0" maxWidth="60.0" minHeight="60.0" minWidth="60.0" mnemonicParsing="false" prefHeight="60.0" prefWidth="60.0" style="-fx-background-radius: 20; -fx-border-radius: 20;">
-               <graphic>
-                  <FontIcon iconLiteral="typ-arrow-sync" iconSize="40" selectionFill="#fcf38e" strokeLineCap="ROUND" />
-               </graphic>
-            </Button>
+            <Button layoutX="30.0" layoutY="21.0" maxHeight="60.0" maxWidth="60.0" minHeight="60.0" minWidth="60.0" mnemonicParsing="false" prefHeight="60.0" prefWidth="60.0" style="-fx-background-radius: 20; -fx-border-radius: 20;" />
+            <Button layoutX="30.0" layoutY="21.0" maxHeight="60.0" maxWidth="60.0" minHeight="60.0" minWidth="60.0" mnemonicParsing="false" prefHeight="60.0" prefWidth="60.0" style="-fx-background-radius: 20; -fx-border-radius: 20;" />
         </buttons>
          <BorderPane.margin>
             <Insets left="20.0" right="20.0" />

--- a/src/main/resources/main/Sample.fxml.bak
+++ b/src/main/resources/main/Sample.fxml.bak
@@ -19,11 +19,10 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 <?import org.controlsfx.control.CheckComboBox?>
-<?import org.controlsfx.control.Rating?>
 <?import org.controlsfx.control.cell.ImageGridCell?>
 <?import org.kordamp.ikonli.javafx.FontIcon?>
 
-<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="800.0" minWidth="600.0" prefHeight="800.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="main.Controller">
+<BorderPane maxHeight="-Infinity" maxWidth="-Infinity" minHeight="800.0" minWidth="600.0" prefHeight="800.0" prefWidth="600.0" xmlns="http://javafx.com/javafx/8.0.172-ea" xmlns:fx="http://javafx.com/fxml/1" fx:controller="main.Controller">
    <top>
       <ButtonBar prefHeight="81.0" prefWidth="580.0">
         <buttons>
@@ -54,13 +53,7 @@
                                           <Insets left="5.0" right="7.0" top="7.0" />
                                        </HBox.margin>
                                     </TextField>
-                                    <CheckComboBox fx:id="checkComboBox" title="Genre">
-                                       <HBox.margin>
-                                          <Insets top="7.0" />
-                                       </HBox.margin>
-                                       <opaqueInsets>
-                                          <Insets right="10.0" />
-                                       </opaqueInsets></CheckComboBox>
+                                    <CheckComboBox fx:id="checkComboBox" />
                                  </children>
                               </HBox>
                               <SplitPane dividerPositions="0.5" orientation="VERTICAL" prefHeight="649.0" prefWidth="600.0">
@@ -94,14 +87,6 @@
                                       </rowConstraints>
                                        <children>
                                           <ImageGridCell prefHeight="110.0" prefWidth="139.0" style="-fx-background-color: RED;" GridPane.columnIndex="1" />
-                                          <AnchorPane prefHeight="45.0" prefWidth="299.0" GridPane.rowIndex="1">
-                                             <children>
-                                                <Rating partialRating="true" prefHeight="32.0" prefWidth="43.0" />
-                                             </children>
-                                             <GridPane.margin>
-                                                <Insets left="10.0" top="10.0" />
-                                             </GridPane.margin>
-                                          </AnchorPane>
                                        </children>
                                     </GridPane>
                                  </items>

--- a/src/test/java/H2hibernate.java
+++ b/src/test/java/H2hibernate.java
@@ -1,3 +1,4 @@
+import model.orm.Genre;
 import model.orm.MovieDetails;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
@@ -13,7 +14,13 @@ public class H2hibernate {
 
         Session session = factory.getCurrentSession();
 
-        MovieDetails movieDetails = new MovieDetails("New",2017);
+        MovieDetails movieDetails = new MovieDetails("TESTmovie",2009);
+
+        movieDetails.addGenre(new Genre(12));
+        movieDetails.addGenre(new Genre(14));
+        movieDetails.addGenre(new Genre(16));
+
+
 
         try {
             session.beginTransaction();

--- a/src/test/java/Subtitle.java
+++ b/src/test/java/Subtitle.java
@@ -1,0 +1,33 @@
+import com.github.wtekiela.opensub4j.api.OpenSubtitlesClient;
+import com.github.wtekiela.opensub4j.impl.OpenSubtitlesClientImpl;
+import com.github.wtekiela.opensub4j.response.SubtitleInfo;
+import org.apache.xmlrpc.XmlRpcException;
+
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.List;
+
+public class Subtitle {
+
+    public static void main(String[] args) {
+
+        List<SubtitleInfo> subtitles = null;
+
+        try {
+            URL serverUrl = new URL("https", "api.opensubtitles.org", 443, "/xml-rpc");
+            OpenSubtitlesClient osClient = new OpenSubtitlesClientImpl(serverUrl);
+            osClient.login("myID", "andPassword", "en", "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:47.0) Gecko/20100101 Firefox/47.0");
+            System.out.println(osClient.isLoggedIn());
+            subtitles = osClient.searchSubtitles("eng", "Friends", "1", "1");
+            osClient.logout();
+        } catch (MalformedURLException e) {
+            e.printStackTrace();
+        } catch (XmlRpcException e) {
+            e.printStackTrace();
+        }
+
+        System.out.println(subtitles.size());
+    }
+
+}

--- a/src/test/resources/hibernate.cfg.xml
+++ b/src/test/resources/hibernate.cfg.xml
@@ -34,6 +34,7 @@
         <property name="hbm2ddl.auto">update</property>
 
         <mapping class="model.orm.MovieDetails"/>
+        <mapping class="model.orm.Genre"/>
 
     </session-factory>
 


### PR DESCRIPTION
Currently, Java11 libraries are not as stable as I would like them to be. For the time being, reverting back to Java8.

This patch removes all the JDK-11 specific libraries and configuration. 

What works

- Web Scrapping from Web
- Filename Parsing
- TMDB API (Not implemented)
- Table View
- Search
- Query-based filtering
- Subtitle API (Not Implemented)